### PR TITLE
Coding guideline For Service

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+files: ^service/
+repos:
+  - repo: https://github.com/pycqa/pylint
+    rev: pylint-2.6.0
+    hooks:
+    -   id: pylint

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,565 @@
+[MASTER]
+
+# Points to relative service directory for local imports
+init-hook='base_dir="global-research-platform/service"; import sys,os,re; _re=re.search(r".+\/" + base_dir, os.getcwd()); project_dir = _re.group() if _re else os.path.join(os.getcwd(), base_dir); sys.path.append(project_dir)'
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        import-error
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=yes
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=2
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string="\t"
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception".
+overgeneral-exceptions=Exception

--- a/.pylintrc
+++ b/.pylintrc
@@ -10,7 +10,7 @@ extension-pkg-whitelist=
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=CVS,alembic,tests
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.

--- a/.pylintrc
+++ b/.pylintrc
@@ -142,7 +142,10 @@ disable=print-statement,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape,
-        import-error
+        import-error,
+        too-few-public-methods,
+        no-self-use,
+        useless-object-inheritance
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,13 @@ Bug fixes must include an example that exposes the issue.
 New features should have tests that exercise its functionality. There is a [YouTube video describing the layers of testing](https://www.youtube.com/watch?v=K6P56qUkCrw0).
 If you're not sure what this means for your code, please ask in your pull request.
 
+### Code standard
+
+Please review the individual __README__ based on which project you are contributing
+
+* Web Application README
+* [Service Application README](service/README.md)
+
 ## Recognizing contributions
 
 We welcome and recognize all contributions from documentation to testing to code development.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ $ pipenv shell
 $ pipenv --python /Users/sam/.pyenv/versions/3.8.6/bin/python shell
 # Now inside the virtual env install tools
 $ pip install -r requirements.txt
+# install dev dependencies
+$ pip install -r requirements-dev.txt
 ```
 ### Building the Web Service
 You will need [Node >= v.14](https://nodejs.org/en/) installed

--- a/service/.flake8
+++ b/service/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-ignore =
-    # one blank line before docstring
-    D203,
-    E128, E126
-exclude = .git,__pycache__,voila
-max-complexity = 10

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,24 @@
+# Global Research Platform Service
+
+This directory serves as the API service that will run the models for calculations and maintain data. The models are obtained from the [Solutions Repository](https://github.com/ProjectDrawdown/solutions).
+
+API Documentation could be found by running the application and accessing the `GET /docs`.
+
+## Project Structure
+```
+|___alembic           - postgres migration package
+|   |____versions     - migration files
+|___api               - core application code
+|   |___db            - database helper
+|   |___queries       - preset queries functions
+|   |___routers       - binding for function paths
+|   |   |___providers - social login functions
+|   |   |___routes    - path binding
+|   |___transforms    - mapper to convert models for API
+|___tests             - unit tests
+```
+
+## Prerequisite
+
+* Python 3.8
+* Postgres

--- a/service/README.md
+++ b/service/README.md
@@ -22,3 +22,17 @@ API Documentation could be found by running the application and accessing the `G
 
 * Python 3.8
 * Postgres
+
+## Code Standard
+
+We rely on `pylint` to maintain code standard. Run it by:
+```sh
+$ pylint service
+```
+
+However to make it easier, we added a pre-commit hook that would only run it againts the changes that you made. To do that, simply go to the `root` directory and run
+```sh
+$ pre-commit install
+```
+
+Now `pylint` will run when you create a commit.

--- a/service/api/db/database.py
+++ b/service/api/db/database.py
@@ -1,3 +1,6 @@
+"""
+    Generate connection to the database
+"""
 from sqlalchemy import create_engine, MetaData
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
@@ -5,10 +8,15 @@ from sqlalchemy.orm import sessionmaker
 metadata = MetaData()
 
 def get_session_maker(database_url):
-    engine = create_engine(
-        database_url
-    )
-    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+	"""
+    Generate database session
+
+    Parameters
+    ----
+    database_url: str
+      the URL of the database
+  """
+	engine = create_engine(database_url)
+	return sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
-

--- a/service/api/db/helpers.py
+++ b/service/api/db/helpers.py
@@ -1,12 +1,25 @@
+"""
+  Cloning query into object
+"""
 from sqlalchemy.orm import Session
 from sqlalchemy.orm import Query
 from sqlalchemy.orm.session import make_transient
 
-def clone(db: Session, query: Query):
-  source_obj = query.all()[0]
+def clone(database: Session, query: Query):
+	"""
+		Queries the database and return result as object
 
-  db.expunge(source_obj)  # expunge the object from session
-  make_transient(source_obj)  # http://docs.sqlalchemy.org/en/rel_1_1/orm/session_api.html#sqlalchemy.orm.session.make_transient
-  delattr(source_obj, 'id')
-  return source_obj
+		Parameters:
+		-----
+		DB: Session
+			session object
+		query: Query
+			Intended query
+	"""
+	source_obj = query.all()[0]
 
+	database.expunge(source_obj)  # expunge the object from session
+	# http://docs.sqlalchemy.org/en/rel_1_1/orm/session_api.html#sqlalchemy.orm.session.make_transient
+	make_transient(source_obj)
+	delattr(source_obj, 'id')
+	return source_obj

--- a/service/api/db/models.py
+++ b/service/api/db/models.py
@@ -1,109 +1,108 @@
 from sqlalchemy import DateTime, Boolean, Column, ForeignKey, Integer, String, Enum, LargeBinary
-from sqlalchemy.dialects.postgresql import JSONB, ARRAY, UUID
+from sqlalchemy.dialects.postgresql import JSONB, ARRAY
 from sqlalchemy.orm import relationship, validates
 from sqlalchemy.ext.hybrid import hybrid_property
 import json
 from jsonschema import validate
 import enum
 from api.config import get_resource_path, get_path
-from uuid import uuid4
 from datetime import datetime
 
 from .database import Base
 from .json_schemas import workbook_schema
 
 class UserRole(enum.Enum):
-  default = 1
+	default = 1
 
 class User(Base):
-  __tablename__ = "user"
+	__tablename__ = "user"
 
-  id = Column(Integer, primary_key=True, index=True)
-  login = Column(String, unique=True, index=True)
-  email = Column(String, unique=True, index=True)
-  provider = Column(String)
-  name = Column(String)
-  company = Column(String)
-  location = Column(String)
-  picture = Column(String)
-  is_active = Column(Boolean, default=True)
-  role = Column(Enum(UserRole), default=UserRole.default)
-  meta = Column(JSONB)
-  workbooks = relationship("Workbook", back_populates="author")
-  vma_csvs = relationship("VMA_CSV", back_populates="author")
+	id = Column(Integer, primary_key=True, index=True)
+	login = Column(String, unique=True, index=True)
+	email = Column(String, unique=True, index=True)
+	provider = Column(String)
+	name = Column(String)
+	company = Column(String)
+	location = Column(String)
+	picture = Column(String)
+	is_active = Column(Boolean, default=True)
+	role = Column(Enum(UserRole), default=UserRole.default)
+	meta = Column(JSONB)
+	workbooks = relationship("Workbook", back_populates="author")
+	vma_csvs = relationship("VMA_CSV", back_populates="author")
 
 class Workbook(Base):
-  __tablename__ = 'workbook'
+	__tablename__ = 'workbook'
 
-  id = Column(Integer, primary_key=True, index=True)
-  version = Column(Integer, default=0)
-  name = Column(String)
-  description = Column(String)
-  regions = Column(ARRAY(String), default=['World'])
-  author_id = Column(Integer, ForeignKey('user.id'))
-  author = relationship("User", back_populates="workbooks")
-  ui = Column(JSONB)
-  start_year = Column(Integer)
-  end_year = Column(Integer)
-  variations = Column(ARRAY(JSONB))
-  has_run = Column(Boolean, default=False)
-  created_at = Column(DateTime, default=datetime.now())
-  updated_at = Column(DateTime, default=datetime.now(), onupdate=datetime.now())
+	id = Column(Integer, primary_key=True, index=True)
+	version = Column(Integer, default=0)
+	name = Column(String)
+	description = Column(String)
+	regions = Column(ARRAY(String), default=['World'])
+	author_id = Column(Integer, ForeignKey('user.id'))
+	author = relationship("User", back_populates="workbooks")
+	ui = Column(JSONB)
+	start_year = Column(Integer)
+	end_year = Column(Integer)
+	variations = Column(ARRAY(JSONB))
+	has_run = Column(Boolean, default=False)
+	created_at = Column(DateTime, default=datetime.now())
+	updated_at = Column(DateTime, default=datetime.now(), onupdate=datetime.now())
 
-  @validates('data')
-  def validate_data(self, key, value):
-    my_json = json.loads(value)
-    # Validate will raise exception if given json is not
-    # what is described in schema.
-    validate(instance=my_json, schema=workbook_schema)
+	@validates('data')
+	def validate_data(self, key, value):
+		my_json = json.loads(value)
+		# Validate will raise exception if given json is not
+		# what is described in schema.
+		validate(instance=my_json, schema=workbook_schema)
 
 class Resource(object):
-  __tablename__ = 'resource'
+	__tablename__ = 'resource'
 
-  id = Column(Integer, primary_key=True)
-  name = Column(String, index=True)
-  data = Column(JSONB)
+	id = Column(Integer, primary_key=True)
+	name = Column(String, index=True)
+	data = Column(JSONB)
 
-  @hybrid_property
-  def path(self):
-    return get_resource_path(self.__tablename__, self.id)
+	@hybrid_property
+	def path(self):
+		return get_resource_path(self.__tablename__, self.id)
 
 class Scenario(Resource, Base):
-  __tablename__ = 'scenario'
+	__tablename__ = 'scenario'
 
 class Reference(Resource, Base):
-  __tablename__ = 'reference'
+	__tablename__ = 'reference'
 
 class Variation(Resource, Base):
-  __tablename__ = 'variation'
+	__tablename__ = 'variation'
 
 class VMA_CSV(Base):
-  __tablename__ = 'vma_csv'
-  id = Column(Integer, primary_key=True)
-  name = Column(String, index=True)
-  technology = Column(String)
-  variable = Column(String)
-  legacy_variable = Column(String)
-  original_filename = Column(String)
-  author_id = Column(Integer, ForeignKey('user.id'))
-  author = relationship("User", back_populates="vma_csvs")
-  data = Column(LargeBinary)
+	__tablename__ = 'vma_csv'
+	id = Column(Integer, primary_key=True)
+	name = Column(String, index=True)
+	technology = Column(String)
+	variable = Column(String)
+	legacy_variable = Column(String)
+	original_filename = Column(String)
+	author_id = Column(Integer, ForeignKey('user.id'))
+	author = relationship("User", back_populates="vma_csvs")
+	data = Column(LargeBinary)
 
-  @hybrid_property
-  def path(self):
-    return get_path(self.__tablename__, self.id)
+	@hybrid_property
+	def path(self):
+		return get_path(self.__tablename__, self.id)
 
 class TAM(Resource, Base):
-  __tablename__ = 'tam'
+	__tablename__ = 'tam'
 
 class VMA(Resource, Base):
-  __tablename__ = 'vma'
+	__tablename__ = 'vma'
 
 class AdoptionData(Resource, Base):
-  __tablename__ = 'adoption_data'
+	__tablename__ = 'adoption_data'
 
 class CustomAdoptionPDS(Resource, Base):
-  __tablename__ = 'ca_pds'
+	__tablename__ = 'ca_pds'
 
 class CustomAdoptionRef(Resource, Base):
-  __tablename__ = 'ca_ref'
+	__tablename__ = 'ca_ref'

--- a/service/api/db/models.py
+++ b/service/api/db/models.py
@@ -1,20 +1,28 @@
+"""
+	Models objects for Postgres database
+"""
+import json
+import enum
+from datetime import datetime
+from jsonschema import validate
 from sqlalchemy import DateTime, Boolean, Column, ForeignKey, Integer, String, Enum, LargeBinary
 from sqlalchemy.dialects.postgresql import JSONB, ARRAY
 from sqlalchemy.orm import relationship, validates
 from sqlalchemy.ext.hybrid import hybrid_property
-import json
-from jsonschema import validate
-import enum
 from api.config import get_resource_path, get_path
-from datetime import datetime
-
 from .database import Base
 from .json_schemas import workbook_schema
 
 class UserRole(enum.Enum):
-	default = 1
+	"""
+		Base enum for User Role
+	"""
+	DEFAULT = 1
 
 class User(Base):
+	"""
+		Represent the User Table
+	"""
 	__tablename__ = "user"
 
 	id = Column(Integer, primary_key=True, index=True)
@@ -26,12 +34,15 @@ class User(Base):
 	location = Column(String)
 	picture = Column(String)
 	is_active = Column(Boolean, default=True)
-	role = Column(Enum(UserRole), default=UserRole.default)
+	role = Column(Enum(UserRole), default=UserRole.DEFAULT)
 	meta = Column(JSONB)
 	workbooks = relationship("Workbook", back_populates="author")
 	vma_csvs = relationship("VMA_CSV", back_populates="author")
 
 class Workbook(Base):
+	"""
+		Represent the Workbook Table
+	"""
 	__tablename__ = 'workbook'
 
 	id = Column(Integer, primary_key=True, index=True)
@@ -50,13 +61,19 @@ class Workbook(Base):
 	updated_at = Column(DateTime, default=datetime.now(), onupdate=datetime.now())
 
 	@validates('data')
-	def validate_data(self, key, value):
+	def validate_data(self, _, value):
+		"""
+			Validate input value with schema
+		"""
 		my_json = json.loads(value)
 		# Validate will raise exception if given json is not
 		# what is described in schema.
 		validate(instance=my_json, schema=workbook_schema)
 
 class Resource(object):
+	"""
+		Represent the Resource Table
+	"""
 	__tablename__ = 'resource'
 
 	id = Column(Integer, primary_key=True)
@@ -65,18 +82,33 @@ class Resource(object):
 
 	@hybrid_property
 	def path(self):
+		"""
+			return resource path
+		"""
 		return get_resource_path(self.__tablename__, self.id)
 
 class Scenario(Resource, Base):
+	"""
+		Represent the Scenario Table
+	"""
 	__tablename__ = 'scenario'
 
 class Reference(Resource, Base):
+	"""
+		Represent the Reference Table
+	"""
 	__tablename__ = 'reference'
 
 class Variation(Resource, Base):
+	"""
+		Represent the Variation Table
+	"""
 	__tablename__ = 'variation'
 
-class VMA_CSV(Base):
+class VMA_CSV(Base): # pylint: disable=invalid-name
+	"""
+		Represent the VMA_CVS Table
+	"""
 	__tablename__ = 'vma_csv'
 	id = Column(Integer, primary_key=True)
 	name = Column(String, index=True)
@@ -90,19 +122,37 @@ class VMA_CSV(Base):
 
 	@hybrid_property
 	def path(self):
+		"""
+			Get the path of VMA
+		"""
 		return get_path(self.__tablename__, self.id)
 
 class TAM(Resource, Base):
+	"""
+		Represent the TAM Table
+	"""
 	__tablename__ = 'tam'
 
 class VMA(Resource, Base):
+	"""
+		Represent the VMA Table
+	"""
 	__tablename__ = 'vma'
 
 class AdoptionData(Resource, Base):
+	"""
+		Represent the Adoption Data Table
+	"""
 	__tablename__ = 'adoption_data'
 
 class CustomAdoptionPDS(Resource, Base):
+	"""
+		Represent the Custom Adoption PDS Table
+	"""
 	__tablename__ = 'ca_pds'
 
 class CustomAdoptionRef(Resource, Base):
+	"""
+		Represent the Custom Adoption Reference Table
+	"""
 	__tablename__ = 'ca_ref'

--- a/service/api/queries/user_queries.py
+++ b/service/api/queries/user_queries.py
@@ -1,23 +1,35 @@
+"""
+  Query set for the User object
+"""
 from sqlalchemy.orm import Session
-from sqlalchemy.orm.query import Query
-
 from api.db import models
-from api.routers import schemas
 
-def get_user(db: Session, user: models.User):
-    return db.query(models.User).filter(models.User.login == user.login).first()
+def get_user(database: Session, user: models.User):
+	"""
+		Get user object from database based on currently logged in user
+  """
+	return database.query(models.User).filter(models.User.login == user.login).first()
 
-def create_user(db: Session, user: models.User):
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return user
+def create_user(database: Session, user: models.User):
+	"""
+    Create new User in the database
+  """
+	database.add(user)
+	database.commit()
+	database.refresh(user)
+	return user
 
-def all_users(db: Session):
-    return db.query(models.User).all()
+def all_users(database: Session):
+	"""
+    Get all user from database
+  """
+	return database.query(models.User).all()
 
-def save_user(db: Session, user: models.User):
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    return user
+def save_user(database: Session, user: models.User):
+	"""
+    Save User object to database
+  """
+	database.add(user)
+	database.commit()
+	database.refresh(user)
+	return user

--- a/service/api/queries/workbook_queries.py
+++ b/service/api/queries/workbook_queries.py
@@ -1,32 +1,56 @@
+"""
+  Query set for the Workbook object
+"""
 from sqlalchemy.orm import Session
 
 from api.db.helpers import clone
 from api.db.models import Workbook as DBWorkbook
 
-def workbook_by_id(db: Session, id: int) -> DBWorkbook:
-    return db.query(DBWorkbook).get(id)
+def workbook_by_id(database: Session, input_id: int) -> DBWorkbook:
+	"""
+		Get Workbook from database by ID
+	"""
+	return database.query(DBWorkbook).get(input_id)
 
-def workbook_by_commit(db: Session, uuid: str) -> DBWorkbook:
-    return db.query(DBWorkbook).filter(DBWorkbook.commit==uuid).first()
+def workbook_by_commit(database: Session, uuid: str) -> DBWorkbook:
+	"""
+		Get Workbook from database by commit
+	"""
+	return database.query(DBWorkbook).filter(DBWorkbook.commit == uuid).first()
 
-def workbooks_by_user_id(db: Session, author_id: int) -> DBWorkbook:
-    return db.query(DBWorkbook).filter(DBWorkbook.author_id==author_id).all()
+def workbooks_by_user_id(database: Session, author_id: int) -> DBWorkbook:
+	"""
+		Get Workbook from database by user ID
+	"""
+	return database.query(DBWorkbook).filter(DBWorkbook.author_id == author_id).all()
 
-def workbooks_by_default_user(db: Session) -> DBWorkbook:
-    return db.query(DBWorkbook).filter(DBWorkbook.author_id.is_(None)).all()
+def workbooks_by_default_user(database: Session) -> DBWorkbook:
+	"""
+		Get Workbook from database when user ID is None
+	"""
+	return database.query(DBWorkbook).filter(DBWorkbook.author_id.is_(None)).all()
 
-def all_workbooks(db: Session, id: int):
-    q1 = db.query(DBWorkbook).filter(DBWorkbook.author_id==id)
-    q2 = db.query(DBWorkbook).filter(DBWorkbook.author_id.is_(None))
-    q3 = q1.union(q2)
-    return q3.all()
+def all_workbooks(database: Session, input_id: int):
+	"""
+		Get all Workbook from datas
+	"""
+	query_1 = database.query(DBWorkbook).filter(DBWorkbook.author_id == input_id)
+	query_2 = database.query(DBWorkbook).filter(DBWorkbook.author_id.is_(None))
+	query_3 = query_1.union(query_2)
+	return query_3.all()
 
-def clone_workbook(db: Session, id: int):
-    cloned = clone(db, db.query(DBWorkbook).filter(DBWorkbook.id==id))
-    return cloned
+def clone_workbook(database: Session, input_id: int):
+	"""
+		Get Workbook by ID and create a local clone
+	"""
+	cloned = clone(database, database.query(DBWorkbook).filter(DBWorkbook.id == input_id))
+	return cloned
 
-def save_workbook(db: Session, workbook: DBWorkbook):
-    db.add(workbook)
-    db.commit()
-    db.refresh(workbook)
-    return workbook
+def save_workbook(database: Session, workbook: DBWorkbook):
+	"""
+		Save Workbook object to database
+	"""
+	database.add(workbook)
+	database.commit()
+	database.refresh(workbook)
+	return workbook

--- a/service/requirements-dev.txt
+++ b/service/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest==6.1.2
+pre-commit==2.13.0

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -10,7 +10,6 @@ jsonschema==3.2.0
 pandas==1.2
 pydantic==1.7.1
 PyJWT==1.7.1
-pytest==6.1.2
 python-dotenv==0.18.0
 python-multipart==0.0.5
 psycopg2==2.9.1


### PR DESCRIPTION
Introduce a pre-commit hook that we can use to maintain code standard. It will take the configuration from `.pylintrc`. Pre-commit is set on individual machine, so user will have to run it manually, but if they are coding using an IDE, it can pick up the `.pylintrc` config and gives them alert from there.

The pre-commit would only check on the files they touched, so we can go along the way in terms of updating documentation.

The final solution would be adding a pre-receive to the repo, but thats too dangerous (right now) as we have a lot of clean up to do.