### PR TITLE
Issue # 40 - allow selected solutions to be distinct from non-selected in portfolio edit

### DIFF
--- a/web/src/components/TechnologyCardPanes.js
+++ b/web/src/components/TechnologyCardPanes.js
@@ -23,6 +23,7 @@ import {
   TechnologyCardGrid,
   SortedTechnologyCardGrid
 } from "components/cards/TechnologyCards";
+import { usePortfolioSolutions } from "helpers";
 
 import styled from "styled-components";
 
@@ -253,10 +254,6 @@ export const TechnologyPane = ({
   const params = useParams();
   const dispatch = useDispatch();
   const workbookState = useSelector(state => state.workbook);
-  const portfolioSolutions =
-    workbookState.workbook && workbookState.workbook.ui
-      ? workbookState.workbook.ui.portfolioSolutions || []
-      : [];
   const gotoAndClose = to => {
     history.push(to);
     return onClose();
@@ -268,15 +265,13 @@ export const TechnologyPane = ({
     return ret;
   }, {});
   const sectorName = reverseTechMap[currentSector] || "\u00A0";
-  const technologyCardIDs = Object.keys(technologyMetadata).filter(
-    techID => technologyMetadata[techID].sector === sectorName
-  )
-  const technologyCardIDsInPortfolio = technologyCardIDs.filter(id =>
-    portfolioSolutions.includes(id)
-  );
-  const technologyCardIDsNotInPortfolio = technologyCardIDs.filter(
-    id => !portfolioSolutions.includes(id)
-  );
+  
+  const {
+    portfolioSolutions,
+    sectorTechnologyIDsInPortfolio,
+    sectorTechnologyIDsNotInPortfolio,
+  } = usePortfolioSolutions(technologyMetadata, sectorName);
+
   const handlePortfolioTechnologyClick = async id => {
     const result = await dispatch(
       doRemovePortfolioTechnologyPatchThunk({
@@ -303,11 +298,11 @@ export const TechnologyPane = ({
       viewLocation={viewLocation}
       currentSector={currentSector}
       color={`brand.${currentSector}.900`}>
-      {technologyCardIDsInPortfolio.length > 0 || sectorEdit ? (
+      {sectorTechnologyIDsInPortfolio.length > 0 ? (
         <TechnologyCardGrid
           mb="0"
           isEditingCards={sectorEdit}
-          technologyIDs={[...technologyCardIDsInPortfolio, ...technologyCardIDsNotInPortfolio]}
+          technologyIDs={sectorTechnologyIDsInPortfolio}
           keyString="technology-soln-"
           sectorName={sectorName}
           makeOnClickFn={technologyID => () => sectorEdit ?
@@ -331,25 +326,26 @@ export const TechnologyPane = ({
             />
           )}
         </TechnologyCardGrid>
-      ) : (
-        <Box>
-          <Text>The portfolio for this workbook is currently empty.</Text>
-          <Text>
-            <Link
-              textDecoration="underline"
-              textColor="brand.blue.700"
-              as={DomLink}
-              to={editLocation}
-            >
-              Add technologies to the portfolio
-            </Link>{" "}
-            to access them quickly.
-          </Text>
-        </Box>
+      ) : (!sectorEdit && (
+          <Box>
+            <Text>The portfolio for this workbook is currently empty.</Text>
+            <Text>
+              <Link
+                textDecoration="underline"
+                textColor="brand.blue.700"
+                as={DomLink}
+                to={editLocation}
+              >
+                Add technologies to the portfolio
+              </Link>{" "}
+              to access them quickly.
+            </Text>
+          </Box>
+        )
       )}
-      {sectorEdit && (
+      {(
         <TechnologyCardGrid
-          technologyIDs={technologyCardIDsNotInPortfolio}
+          technologyIDs={sectorTechnologyIDsNotInPortfolio}
           keyString="technology-soln-"
           sectorName={sectorName}
           makeOnClickFn={technologyID => () => sectorEdit ?
@@ -359,30 +355,6 @@ export const TechnologyPane = ({
           isFeaturedFn={() => true}>
         </TechnologyCardGrid>
       )}
-      {/*<TechnologyCardGrid
-        technologyIDs={technologyCardIDsNotInPortfolio}
-        cols={sidebar ? 3 : 4}
-        keyString="technology-soln-"
-        makeOnClickFn={technologyID => () =>
-          gotoAndClose(`/workbook/${params.id}/technologies/${technologyID}`)}
-        isSelectedFn={technologyID => portfolioSolutions.includes(technologyID)}
-        isFeaturedFn={() => false}
-      >
-        {currentSector === "electricity" && (
-          <TechnologyCard
-            conventional={true}
-            color={"grey"}
-            techID={"conventional"}
-            featured={false}
-            title={"Conventional Technologies"}
-            technologyImage={""}
-            onClick={() =>
-              gotoAndClose(`/workbook/${params.id}/technologies/conventional`)
-            }
-            selected={activeTechnology === "conventional"}
-          />
-        )}
-      </TechnologyCardGrid>*/}
     </TechnologyCardPaneWrapper>
   );
 };

--- a/web/src/components/cards/TechnologyCards.js
+++ b/web/src/components/cards/TechnologyCards.js
@@ -10,6 +10,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 
 import { useConfigContext } from "contexts/ConfigContext";
+import { usePortfolioSolutions } from "helpers";
 
 import styled from "styled-components";
 
@@ -238,6 +239,71 @@ export const TechnologyCardGrid = ({
   );
 };
 
+export const SectorGrid = ({
+  isEditingPortfolio,
+  technologyMetadata,
+  sectorName,
+  makeOnClickFn,
+  isSelectedFn,
+  isFeaturedFn,
+  keyString,
+  cols
+}) => {
+  const {
+    sectorTechnologyIDsInPortfolio,
+    sectorTechnologyIDsNotInPortfolio,
+  } = usePortfolioSolutions(technologyMetadata, sectorName);
+  
+  // add these constants here for ease of making sense of 
+  // what to display when
+  const hasSolutionsInSector = sectorTechnologyIDsInPortfolio.length > 0 || sectorTechnologyIDsNotInPortfolio.length > 0;
+  
+  const shouldDisplayHeader = isEditingPortfolio 
+    ? hasSolutionsInSector 
+    : sectorTechnologyIDsInPortfolio.length > 0
+  const shouldDisplaySelected = sectorTechnologyIDsInPortfolio.length > 0;
+  const shouldDisplayNotSelected = (isEditingPortfolio && sectorTechnologyIDsNotInPortfolio.length > 0);
+
+  return (
+    <React.Fragment>
+      {shouldDisplayHeader && (
+        <Heading as="h3" textStyle={"portfolioTech"}>
+          {sectorName}
+        </Heading>
+      )}
+      {shouldDisplaySelected && ( 
+        <TechnologyCardGrid
+            {...{
+              isEditingCards: isEditingPortfolio,
+              technologyIDs: sectorTechnologyIDsInPortfolio,
+              makeOnClickFn,
+              isSelectedFn,
+              isFeaturedFn,
+              sectorName,
+              keyString,
+              cols
+            }}
+        />
+      )}  
+      {shouldDisplayNotSelected && (
+        <TechnologyCardGrid
+          {...{
+            isEditingCards: isEditingPortfolio,
+            technologyIDs: sectorTechnologyIDsNotInPortfolio,
+            makeOnClickFn,
+            isSelectedFn,
+            isFeaturedFn,
+            sectorName,
+            keyString,
+            cols
+          }}
+        />
+        )
+      }
+    </React.Fragment>
+  );
+};
+
 export const SortedTechnologyCardGrid = ({
   isEditingPortfolio,
   technologyIDs,
@@ -250,28 +316,17 @@ export const SortedTechnologyCardGrid = ({
   const {
     settings: { technologyMetadata, techMap }
   } = useConfigContext();
-  return Object.keys(techMap).map(sectorName => {
-    const sectorSolutions = technologyIDs.filter(
-      technologyID => technologyMetadata[technologyID].sector === sectorName
-    );
-    return sectorSolutions.length !== 0 ? (
-      <React.Fragment key={sectorName}>
-        <Heading as="h3" textStyle={"portfolioTech"}>
-          {sectorName}
-        </Heading>
-        <TechnologyCardGrid
-          {...{
-            isEditingCards: isEditingPortfolio,
-            technologyIDs: sectorSolutions,
-            makeOnClickFn,
-            isSelectedFn,
-            isFeaturedFn,
-            sectorName,
-            keyString,
-            cols
-          }}
-        />
-      </React.Fragment>
-    ) : null;
-  });
+  return Object.keys(techMap).map(sectorName => 
+    <SectorGrid  
+      key={sectorName}
+      isEditingPortfolio={isEditingPortfolio}
+      technologyMetadata={technologyMetadata}
+      sectorName={sectorName}
+      makeOnClickFn={makeOnClickFn}
+      isSelectedFn={isSelectedFn}
+      isFeaturedFn={isFeaturedFn}
+      keyString={keyString}
+      cols={cols}
+    />
+  );
 };

--- a/web/src/helpers.js
+++ b/web/src/helpers.js
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
 
 export function useLocalStorage(key, initialValue) {
   // State to store our value
@@ -50,4 +51,64 @@ export function useLocalStorage(key, initialValue) {
     }
   };
   return [storedValue, setValue, removeValue];
+}
+
+/**
+ * Custom hook that filters technologyIDs by sector and breaks them into 2 arrays: 
+ *  - those that are selected in the portfolio 
+ *  - those that are NOT selected 
+ * This information is reused across multiple pages in the application - looking 
+ * at all the solutions for a portfolio and looking at solutions in a sector. 
+ * Putting it in a common hooks location allows it to be reused.
+ * 
+ * @param {*} technologyMetadata - derived from config and contains information 
+ *                                 about the different technology sectors and solutions
+ * @param {*} sectorName - Name of the sector that is being processed
+ * @returns 
+ * object with the given structure:
+ * {
+ *   portfolioSolutions, // all selected solutions across sectors for the portfolio
+ *   sectorTechnologyIDsInPortfolio,  // selected solution IDs in given sector
+ *   sectorTechnologyIDsNotInPortfolio, // solution IDS in given sector that are NOT selected
+ * }
+ */
+export function usePortfolioSolutions(technologyMetadata, sectorName){
+  const workbookState = useSelector(state => state.workbook);
+
+  const [portfolioSolutions, setPortfolioSolutions] = useState([]);
+  const [sectorTechnologyIDsInPortfolio, setSectorTechnologyIDsInPortfolio] =
+    useState([]);
+  const [sectorTechnologyIDsNotInPortfolio, setSectorTechnologyIDsNotInPortfolio] =
+    useState([]);
+
+  const technologyIDsInSector = useMemo(
+    () =>
+      Object.keys(technologyMetadata).filter(
+        (techologyID) => technologyMetadata[techologyID].sector === sectorName
+      ),
+    [technologyMetadata, sectorName]
+  );
+  
+  useEffect(() => {
+    setPortfolioSolutions(
+      workbookState.workbook && workbookState.workbook.ui
+        ? workbookState.workbook.ui.portfolioSolutions || []
+        : []
+    );
+  }, [workbookState.workbook]);
+  
+  useEffect(() => {
+    setSectorTechnologyIDsInPortfolio(
+      technologyIDsInSector.filter((id) => portfolioSolutions.includes(id))
+    );
+    setSectorTechnologyIDsNotInPortfolio(
+      technologyIDsInSector.filter((id) => !portfolioSolutions.includes(id))
+    );
+  }, [portfolioSolutions, technologyIDsInSector]);
+  
+  return {
+    portfolioSolutions, // all the selected solutions across sectors in the portfolio
+    sectorTechnologyIDsInPortfolio,  // technology solution IDs in given sector that are selected
+    sectorTechnologyIDsNotInPortfolio, // technology solution IDS in given sector NOT selected
+  }
 }

--- a/web/src/parts/PortfolioLayout/index.js
+++ b/web/src/parts/PortfolioLayout/index.js
@@ -18,7 +18,6 @@ const PortfolioLayout = ({
         pt="1rem"
         flex="1"
         maxW="none"
-        position="fixed"
         ml={navMargin ? "3rem" : 0}
         mb="6rem"
         w={`calc(${maxW} - ${navMargin ? "3" : "0"}rem)`}


### PR DESCRIPTION
Fixes #40 

This PR builds on the solution for Issue #46 - dries it up by
moving that solution to a reusable hook and then applying it
to the portfolio view and edit page.

Also includes a fix for a scrolling issue on the Edit Portfolio page.

Here's some screenshots from my devstack:
![image](https://user-images.githubusercontent.com/61206123/126914448-91034f00-006e-4105-bd0c-f189eae7f8a2.png)

p.s. it might be easier to simply merge this PR and NOT merge https://github.com/ProjectDrawdown/global-research-platform/pull/70 - since this PR contains the fix introduced there.